### PR TITLE
Adding Xdmf support to Spack package

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ $ spack info adcirc
 ```
 
 This will print out a listing of available versions and options for use within the spack package. Unless you have specific needs,
-it is recommended to use the preferred version. While development and master are both listed as "safe", the only version that should 
+it is recommended to use the preferred version. 
 
 ```bash
 $ spack install adcirc@56.0.2
@@ -89,13 +89,13 @@ will build (by default) ADCIRC in serial and parallel with netCDF enabled. Addit
 `padcswan`, and `aswip`) can be enabled by specificying additional flags to Spack as shown below:
 
 ```bash
-$ spack install adcirc@develop +swan +aswip
+$ spack install adcirc +swan +aswip
 ```
 
 If you'd like to change the compiler that is used to build adcirc, you can pass that using:
 
 ```bash
-$ spack install adcirc@develop %oneapi
+$ spack install adcirc %oneapi
 ```
 This will build ADCIRC using the Intel-LLVM (i.e. Intel OneAPI) compilers. Note that only ADCIRC version 56.00+ 
 is compatible with the Intel-LLVM compiler suite. Note that you'll need to ensure these compilers are installed/enabled
@@ -129,7 +129,7 @@ oneapi@2022.2.1
 Another variant would be to enable the system to build OpenMPI from source using Intel-LLVM with SLURM support:
 
 ```bash
-$ spack install adcirc@develop ^openmpi+legacylaunchers schedulers=slurm %oneapi
+$ spack install adcirc ^openmpi+legacylaunchers schedulers=slurm %oneapi
 ```
 
 If you'd like to build with your specific mpi library, you should provide the specification that matches the 

--- a/packages/adcirc/package.py
+++ b/packages/adcirc/package.py
@@ -60,18 +60,54 @@ class Adcirc(CMakePackage):
 
     # ...Package location and sample archive name
     git = "https://github.com/adcirc/adcirc.git"
-    url = "https://github.com/adcirc/adcirc/releases/download/v55.02/adcirc_v55.02.tar.gz"
+    url = (
+        "https://github.com/adcirc/adcirc/releases/download/v55.02/adcirc_v55.02.tar.gz"
+    )
 
     # ...ADCIRC versions
-    version("56.0.2", sha256="74e0dff04ae25200f4bf3cc7b0f344595770e70b193a9ea928e76a86b17d83ba", preferred=True)
-    version("56.0.1", sha256="cba0663722cfbfcc2c49dd01facb525d8ad49fe5f41c2017ce81173e3618b862")
-    version("56.0.0", sha256="2c53ebe89eb1bc1a6426781fdf9f8fdd8cb93261bfedb6afd59b94b926fc1c78")
-    version("55.02", sha256="10029efccf25796f5190d9ace89af5b371bf874b746de6116543ee136e9334ee")
-    version("55.01", sha256="fa42ff973e157634ed6bedae9465067928944901524cc255c561b24db2d41b27", deprecated=True)
-    version("55.00", sha256="0de3bbdeb69b8809d668d511f10e8f4784f253d278e1985c3bbd3907725142d7", deprecated=True)
-    version("54.02", sha256="cb1aca0cc7a0b1b0c4cc91ad71a2ac2cbefc0a16d5ff25d6d2833e75b0fc5262")
-    version("54.01", sha256="ff31a458c529f7ad970cf4ae099cbf0da9e949ad35af01be1e23e19dbb0ca6ca", deprecated=True)
-    version("54.00", sha256="6c2ac516b7ebb0508e2f3fdc684170f78b6f0e949f6ebcf98dc9208e304f3d18", deprecated=True)
+    version(
+        "56.0.2",
+        sha256="74e0dff04ae25200f4bf3cc7b0f344595770e70b193a9ea928e76a86b17d83ba",
+        preferred=True,
+    )
+    version(
+        "56.0.1",
+        sha256="cba0663722cfbfcc2c49dd01facb525d8ad49fe5f41c2017ce81173e3618b862",
+        deprecated=True,
+    )
+    version(
+        "56.0.0",
+        sha256="2c53ebe89eb1bc1a6426781fdf9f8fdd8cb93261bfedb6afd59b94b926fc1c78",
+        deprecated=True,
+    )
+    version(
+        "55.02",
+        sha256="10029efccf25796f5190d9ace89af5b371bf874b746de6116543ee136e9334ee",
+    )
+    version(
+        "55.01",
+        sha256="fa42ff973e157634ed6bedae9465067928944901524cc255c561b24db2d41b27",
+        deprecated=True,
+    )
+    version(
+        "55.00",
+        sha256="0de3bbdeb69b8809d668d511f10e8f4784f253d278e1985c3bbd3907725142d7",
+        deprecated=True,
+    )
+    version(
+        "54.02",
+        sha256="cb1aca0cc7a0b1b0c4cc91ad71a2ac2cbefc0a16d5ff25d6d2833e75b0fc5262",
+    )
+    version(
+        "54.01",
+        sha256="ff31a458c529f7ad970cf4ae099cbf0da9e949ad35af01be1e23e19dbb0ca6ca",
+        deprecated=True,
+    )
+    version(
+        "54.00",
+        sha256="6c2ac516b7ebb0508e2f3fdc684170f78b6f0e949f6ebcf98dc9208e304f3d18",
+        deprecated=True,
+    )
 
     version("main", branch="main")
 
@@ -85,6 +121,12 @@ class Adcirc(CMakePackage):
         description="Builds the model with GRIB format enabled",
         when=("@55:+netcdf"),
     )
+    variant(
+        "xdmf",
+        default=False,
+        description="Builds the model with XDMF3 format support",
+    )
+
     variant("mpi", default=True, description="Builds the parallel executables")
     variant(
         "swan", default=False, description="Builds the tightly coupled SWAN wave model"
@@ -99,18 +141,21 @@ class Adcirc(CMakePackage):
     variant(
         "utilities", default=False, description="Builds the adcirc utilities package"
     )
-    variant(
-        "warnelev", default=False, description="Uses warning elevation debug options"
-    )
 
     # ...Dependencies
+    depends_on("c", type="build")  
+    depends_on("fortran", type="build")
     depends_on("cmake@3:", type="build")
     depends_on("perl", type="build", when="+swan")
-    depends_on("hdf5~mpi~threadsafe", when="+netcdf", type=("build", "link", "run"))
-    depends_on("netcdf-c@4:~mpi", when="+netcdf", type=("build", "link", "run"))
-    depends_on("netcdf-fortran@4:", when="+netcdf", type=("build", "link", "run"))
-    depends_on("mpi", when="+mpi", type=("build", "link", "run"))
+    depends_on("hdf5~mpi~threadsafe", when="+netcdf", type=("build", "link"))
+    depends_on("netcdf-c@4:~mpi", when="+netcdf", type=("build", "link"))
+    depends_on("netcdf-fortran@4:", when="+netcdf", type=("build", "link"))
+    depends_on("mpi", when="+mpi", type=("build", "link"))
     depends_on("jpeg", when="+grib", type=("build", "link"))
+    depends_on("xdmf3~mpi+fortran", when="+xdmf", type=("build", "link"))
+    depends_on("hdf5~mpi~threadsafe", when="+xdmf", type=("build", "link"))
+    depends_on("netcdf-c@4:~mpi", when="+xdmf", type=("build", "link"))
+    depends_on("netcdf-fortran@4:", when="+xdmf", type=("build", "link"))
 
     def url_for_version(self, version):
         """
@@ -126,8 +171,9 @@ class Adcirc(CMakePackage):
     def cmake_args(self):
         args = []
 
-        if "+netcdf" in self.spec:
+        if "+netcdf" in self.spec or "+xdmf" in self.spec:
             args.append(self.define("ENABLE_OUTPUT_NETCDF", True))
+            args.append(self.define("NETCDFHOME", self.spec["netcdf-c"].prefix))
             args.append(
                 self.define("NETCDF_F90_ROOT", self.spec["netcdf-fortran"].prefix)
             )
@@ -135,6 +181,10 @@ class Adcirc(CMakePackage):
         if "+grib" in self.spec:
             args.append(self.define("ENABLE_GRIB2", True))
             args.append(self.define("ENABLE_DATETIME", True))
+
+        if "+xdmf" in self.spec:
+            args.append(self.define("ENABLE_OUTPUT_XDMF", True))
+            args.append(self.define("XDMFHOME", self.spec["xdmf3"].prefix))
 
         if "+swan" in self.spec:
             args.append(self.define("BUILD_ADCSWAN", True))

--- a/packages/xdmf3/fix_hdf5_hid_t.diff
+++ b/packages/xdmf3/fix_hdf5_hid_t.diff
@@ -1,0 +1,40 @@
+diff --git a/core/XdmfHDF5Controller.hpp b/core/XdmfHDF5Controller.hpp
+index c5c15d0a..496cc80d 100644
+--- a/core/XdmfHDF5Controller.hpp
++++ b/core/XdmfHDF5Controller.hpp
+@@ -27,13 +27,14 @@
+ // C Compatible Includes
+ #include "XdmfCore.hpp"
+ #include "XdmfHeavyDataController.hpp"
++#include <cstdint>
+ 
+ // So that hdf5 does not need to be included in the header files
+ // It would add a dependancy to programs that use Xdmf
+ #ifndef _H5Ipublic_H
+   #ifndef XDMF_HID_T
+   #define XDMF_HID_T
+-    typedef int hid_t;
++    typedef int64_t hid_t;
+   #endif
+ #endif
+ 
+diff --git a/core/XdmfHDF5Writer.hpp b/core/XdmfHDF5Writer.hpp
+index cfbec6f4..f83aa0de 100644
+--- a/core/XdmfHDF5Writer.hpp
++++ b/core/XdmfHDF5Writer.hpp
+@@ -28,13 +28,14 @@
+ #include "XdmfCore.hpp"
+ #include "XdmfHeavyDataWriter.hpp"
+ #include "XdmfHeavyDataController.hpp"
++#include <cstdint>
+ 
+ // So that hdf5 does not need to be included in the header files
+ // It would add a dependancy to programs that use Xdmf
+ #ifndef _H5Ipublic_H
+   #ifndef XDMF_HID_T
+   #define XDMF_HID_T
+-    typedef int hid_t;
++    typedef int64_t hid_t;
+   #endif
+ #endif
+ 

--- a/packages/xdmf3/package.py
+++ b/packages/xdmf3/package.py
@@ -1,0 +1,60 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+from spack.pkg.builtin.boost import Boost
+
+
+class Xdmf3(CMakePackage):
+    """XDMF, or eXtensible Data Model and Format (XDMF), is a common data model
+    format to exchange scientific data between High Performance Computing
+    codes and tools.
+    """
+
+    homepage = "https://xdmf.org"
+    git = "https://gitlab.kitware.com/xdmf/xdmf.git"
+
+    license("BSD-3-Clause")
+
+    # There is no official release of XDMF and development has largely ceased,
+    # but the current version, 3.x, is maintained on the master branch.
+    version("2019-01-14", commit="8d9c98081d89ac77a132d56bc8bef53581db4078")
+
+    depends_on("c", type="build")  # generated
+    depends_on("cxx", type="build")  # generated
+    depends_on("fortran", type="build", when="+fortran")  # generated
+
+    variant("shared", default=True, description="Enable shared libraries")
+    variant("mpi", default=True, description="Enable MPI")
+    variant("fortran", default=False, description="Enable Fortran API")
+
+    depends_on("libxml2")
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)
+    depends_on("mpi", when="+mpi")
+    depends_on("hdf5@1.10:+mpi", when="+mpi")
+    depends_on("hdf5@1.10:~mpi", when="~mpi")
+    # motivated by discussion in https://gitlab.kitware.com/xdmf/xdmf/-/issues/28
+    patch("fix_hdf5_hid_t.diff")
+
+    def cmake_args(self):
+        """Populate cmake arguments for XDMF."""
+        spec = self.spec
+
+        cmake_args = [
+            "-DBUILD_SHARED_LIBS=%s" % str("+shared" in spec),
+            "-DXDMF_BUILD_UTILS=ON",
+            "-DXDMF_WRAP_JAVA=OFF",
+            "-DXDMF_WRAP_PYTHON=OFF",
+            "-DXDMF_BUILD_TESTING=OFF",
+        ]
+
+        if "+fortran" in self.spec:
+            cmake_args.append("-DXDMF_BUILD_FORTRAN=ON")
+
+        return cmake_args


### PR DESCRIPTION
Note that the default Xdmf spack package does not build the Fortran API, so we've temporarily created our own Xdmf3 package. We'll work to get this upstreamed